### PR TITLE
Add Pinecone RAG to Chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ To test in workspace:
 
 1. Change ports in `app.sh` to `8887`
 2. Run `./app.sh`
-3. Go to `https://{domino-url}/{username}/{domino-project-name}/notebookSession/{runId}/proxy/8887/`
+3. Go to `https://{domino-url}/{username}/{domino-project-name}/r/notebookSession/{runId}/proxy/8887/`

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ RUN pip install streamlit pypdf pinecone-client ipywidgets langchain
 
 # Local Testing
 
+Create a project and mount this git repository instead of using the default Domino File System.
+
 To test in workspace:
 
-1. Changes ports in `app.sh` to `8887`
+1. Change ports in `app.sh` to `8887`
 2. Run `./app.sh`
 3. Go to `https://{domino-url}/{username}/{domino-project-name}/notebookSession/{runId}/proxy/8887/`

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Base image: `Domino Standard Environment Py3.9 R4.3` (in Domino 5.10)
 Additional dockerfile instructions:
 ```
 RUN pip install streamlit pypdf pinecone-client ipywidgets langchain
+RUN pip install --user dominodatalab-data==5.10.0.dev2
+RUN pip install --user pinecone-client==2.2.4
 ```
 
 # Local Testing

--- a/app.sh
+++ b/app.sh
@@ -2,9 +2,9 @@ mkdir -p ~/.streamlit
 echo "[browser]" > ~/.streamlit/config.toml
 echo "gatherUsageStats = true" >> ~/.streamlit/config.toml
 echo "serverAddress = \"0.0.0.0\"" >> ~/.streamlit/config.toml
-echo "serverPort = 8888" >> ~/.streamlit/config.toml
+echo "serverPort = 8887" >> ~/.streamlit/config.toml
 echo "[server]" >> ~/.streamlit/config.toml
-echo "port = 8888" >> ~/.streamlit/config.toml
+echo "port = 8887" >> ~/.streamlit/config.toml
 echo "enableCORS = false" >> ~/.streamlit/config.toml
 echo "enableXsrfProtection = false" >> ~/.streamlit/config.toml
 

--- a/app.sh
+++ b/app.sh
@@ -2,9 +2,9 @@ mkdir -p ~/.streamlit
 echo "[browser]" > ~/.streamlit/config.toml
 echo "gatherUsageStats = true" >> ~/.streamlit/config.toml
 echo "serverAddress = \"0.0.0.0\"" >> ~/.streamlit/config.toml
-echo "serverPort = 8887" >> ~/.streamlit/config.toml
+echo "serverPort = 8888" >> ~/.streamlit/config.toml
 echo "[server]" >> ~/.streamlit/config.toml
-echo "port = 8887" >> ~/.streamlit/config.toml
+echo "port = 8888" >> ~/.streamlit/config.toml
 echo "enableCORS = false" >> ~/.streamlit/config.toml
 echo "enableXsrfProtection = false" >> ~/.streamlit/config.toml
 

--- a/chatbot.py
+++ b/chatbot.py
@@ -4,12 +4,37 @@ import mlflow
 import json
 import requests
 import pandas as pd
+import pinecone
 from mlflow.deployments import get_deploy_client
 from ui.sidebar import build_sidebar
+from langchain_community.embeddings import MlflowEmbeddings
+from domino_data.vectordb import DominoPineconeConfiguration
 
 # Initialize Mlflow client
 client = get_deploy_client(os.environ["DOMINO_MLFLOW_DEPLOYMENTS"])
 mlflow.set_experiment("chatbot-app")
+
+# Initialize Pinecone index
+datasource_name = "PineconeHackathon"
+conf = DominoPineconeConfiguration(datasource=datasource_name)
+api_key = os.environ.get("DOMINO_VECTOR_DB_METADATA", datasource_name)
+
+pinecone.init(
+    api_key=api_key,
+    environment="domino",
+    openapi_config=conf
+)
+
+# Choose appropriate index from Pinecone
+# index_name = "hacktestlatestall"
+index_name = "hacktest"
+index = pinecone.Index(index_name)
+
+# Create embeddings to embed queries
+embeddings = MlflowEmbeddings(
+    target_uri=os.environ["DOMINO_MLFLOW_DEPLOYMENTS"],
+    endpoint="embeddings",
+)
 
 # App title
 st.set_page_config(page_title="Domino Pippy ChatAssist", layout="wide")
@@ -37,16 +62,22 @@ if prompt := st.chat_input("Chat with Pippy"):
 
 # Get relevant docs through vector DB
 def get_relevant_docs(user_input):
-    relevant_docs = "Hi"
-    return relevant_docs
+    embedded_query = embeddings.embed_query(user_input)
+    return index.query(
+        vector=embedded_query,
+        top_k=3,
+        include_values=True
+    )
 
 # Query the Open AI Model
 def queryOpenAIModel(user_input, past_user_inputs=None, generate_responses=None):
 
-    relevant_docs = get_relevant_docs(user_input)
+    #relevant_docs = get_relevant_docs(user_input)
+    #print(relevant_docs)
+    relevant_docs = ""
     
-    system_prompt = """ If the user asks a question that is not related to Domino Data Labs, AI, or machine learning, respond with the following keyword: https://www.youtube.com/watch?v=dQw4w9WgXcQ. 
-                    Otherwise, you are a virtual assistant for Domino Data Labs and your task is to answer questions related to Domino Data Labs which includes general AI/machine learning concepts.
+    system_prompt = """ If the user asks a question that is not related to Domino Data Lab, AI, or machine learning, respond with the following keyword: https://www.youtube.com/watch?v=dQw4w9WgXcQ. 
+                    Otherwise, you are a virtual assistant for Domino Data Lab and your task is to answer questions related to Domino Data Lab which includes general AI/machine learning concepts.
                     When answering questions, only refer to the latest version of Domino. Do not use information from older versions of Domino. 
                     In your response, include a list of the references (with URL links) where you obtained the information from.
                     Here is some relevant context: {}""".format(relevant_docs)

--- a/chatbot.py
+++ b/chatbot.py
@@ -116,8 +116,9 @@ def queryOpenAIModel(user_input, past_user_inputs=None, generate_responses=None)
     system_prompt = """ If the user asks a question that is not related to Domino Data Lab, AI, or machine learning, respond with the following keyword: https://www.youtube.com/watch?v=dQw4w9WgXcQ. 
                     Otherwise, you are a virtual assistant for Domino Data Lab and your task is to answer questions related to Domino Data Lab which includes general AI/machine learning concepts.
                     When answering questions, only refer to the {} version of Domino. Do not use information from older versions of Domino.
-                    When answering questions, only refer to the latest version of Domino. Do not use information from older versions of Domino. 
                     In your response, include the following url links at the end of your response {}.
+                    Also, at the end of your response, ask if your response was helpful and to please file a ticket with our support team at this link if further help is needed: 
+                    https://tickets.dominodatalab.com/hc/en-us/requests/new#numberOfResults=5, embedded into the words "Support Ticket".
                     Here is some relevant context: {}""".format("", ", ".join(url_links), ". ".join(context))
 
     response = client.predict(

--- a/embed_gen/docs_embedder.ipynb
+++ b/embed_gen/docs_embedder.ipynb
@@ -11,6 +11,7 @@
    "source": [
     "from domino_data.vectordb import DominoPineconeConfiguration\n",
     "from langchain.chains.question_answering import load_qa_chain\n",
+    "from langchain_community.embeddings import MlflowEmbeddings\n",
     "from langchain.embeddings.openai import OpenAIEmbeddings\n",
     "from langchain.document_loaders import PyPDFLoader\n",
     "from langchain.llms import OpenAI\n",
@@ -267,18 +268,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 337,
-   "id": "6962d97c-24f4-4fe8-98b4-60beb60cafb9",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "OPENAI_API_KEY = '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'"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "8f0b540d-b0e1-4dc9-9dbd-f7cba85cc628",
    "metadata": {
@@ -309,7 +298,10 @@
    },
    "outputs": [],
    "source": [
-    "embeddings = OpenAIEmbeddings(openai_api_key=OPENAI_API_KEY)"
+    "embeddings = MlflowEmbeddings(\n",
+    "    target_uri=os.environ[\"DOMINO_MLFLOW_DEPLOYMENTS\"],\n",
+    "    endpoint=\"embeddings\",\n",
+    ")"
    ]
   },
   {

--- a/embed_gen/docs_embedder.ipynb
+++ b/embed_gen/docs_embedder.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 330,
+   "execution_count": 2,
    "id": "54672568-dff4-48ea-be39-1bfda56677e5",
    "metadata": {
     "tags": []
@@ -47,9 +47,9 @@
    },
    "outputs": [],
    "source": [
-    "data_dir = \"sample_data\"\n",
-    "metadata_file_path = data_dir + \"/pages.csv\"\n",
-    "page_pdfs_dir_path = data_dir + \"/pdfs\""
+    "# replace with path to your .csv metada file + pdfs directory\n",
+    "metadata_file_path = data_dir + \"/domino/datasets/local/Dataset_source_pdfs/pages.csv\"\n",
+    "page_pdfs_dir_path = data_dir + \"/domino/datasets/local/Dataset_source_pdfs/pdfs\""
    ]
   },
   {


### PR DESCRIPTION
<img width="1717" alt="Screenshot 2024-01-11 at 2 52 49 AM" src="https://github.com/ddl-jwu/domino-chatbot/assets/140661003/c8486fa2-d458-4180-971b-b970139f156e">

- Uses Pinecone vector embeddings as a reference to tailor answer
- Adds relevant URLs from the vectors it found in message
- Can filter by metadata using ~key=value like ~version=5.1